### PR TITLE
FIX: assert fails on type check (int vs bool)

### DIFF
--- a/putty.h
+++ b/putty.h
@@ -1501,10 +1501,10 @@ NORETURN void cleanup_exit(int);
     X(BOOL, NONE, crhaslf) \
     X(STR, NONE, winclass) \
     /* HACK: PuTTY-url settings */ \
-    X(INT, NONE, url_ctrl_click) \
+    X(BOOL, NONE, url_ctrl_click) \
     X(INT, NONE, url_underline) \
-    X(INT, NONE, url_defbrowser) \
-    X(INT, NONE, url_defregex) \
+    X(BOOL, NONE, url_defbrowser) \
+    X(BOOL, NONE, url_defregex) \
     X(FILENAME, NONE, url_browser) \
     X(STR, NONE, url_regex) \
     /* end of list */

--- a/settings.c
+++ b/settings.c
@@ -783,10 +783,10 @@ void save_open_settings(settings_w *sesskey, Conf *conf)
 
     /* PuTTY-url */
     write_setting_i(sesskey, "HyperlinkUnderline", conf_get_int(conf, CONF_url_underline));
-    write_setting_i(sesskey, "HyperlinkUseCtrlClick", conf_get_int(conf, CONF_url_ctrl_click));
-    write_setting_i(sesskey, "HyperlinkBrowserUseDefault", conf_get_int(conf, CONF_url_defbrowser));
+    write_setting_b(sesskey, "HyperlinkUseCtrlClick", conf_get_bool(conf, CONF_url_ctrl_click));
+    write_setting_b(sesskey, "HyperlinkBrowserUseDefault", conf_get_bool(conf, CONF_url_defbrowser));
     write_setting_filename(sesskey, "HyperlinkBrowser", conf_get_filename(conf, CONF_url_browser));
-    write_setting_i(sesskey, "HyperlinkRegularExpressionUseDefault", conf_get_int(conf, CONF_url_defregex));
+    write_setting_b(sesskey, "HyperlinkRegularExpressionUseDefault", conf_get_bool(conf, CONF_url_defregex));
     write_setting_s(sesskey, "HyperlinkRegularExpression", conf_get_str(conf, CONF_url_regex));
 }
 
@@ -1259,10 +1259,10 @@ void load_open_settings(settings_r *sesskey, Conf *conf)
 
     /* PuTTY-url */
     gppi(sesskey, "HyperlinkUnderline", 1, conf, CONF_url_underline);
-    gppi(sesskey, "HyperlinkUseCtrlClick", 0, conf, CONF_url_ctrl_click);
-    gppi(sesskey, "HyperlinkBrowserUseDefault", 1, conf, CONF_url_defbrowser);
+    gppb(sesskey, "HyperlinkUseCtrlClick", 0, conf, CONF_url_ctrl_click);
+    gppb(sesskey, "HyperlinkBrowserUseDefault", 1, conf, CONF_url_defbrowser);
     gppfile(sesskey, "HyperlinkBrowser", conf, CONF_url_browser);
-    gppi(sesskey, "HyperlinkRegularExpressionUseDefault", 1, conf, CONF_url_defregex);
+    gppb(sesskey, "HyperlinkRegularExpressionUseDefault", 1, conf, CONF_url_defregex);
     gpps(sesskey, "HyperlinkRegularExpression", urlhack_default_regex, conf, CONF_url_regex);
 }
 

--- a/terminal.c
+++ b/terminal.c
@@ -5237,7 +5237,7 @@ static void do_paint(Terminal *term)
 
     int urlhack_underline =
         conf_get_int(term->conf, CONF_url_underline) == URLHACK_UNDERLINE_ALWAYS ||
-        (conf_get_int(term->conf, CONF_url_underline) == URLHACK_UNDERLINE_HOVER && (!conf_get_int(term->conf, CONF_url_ctrl_click) || urlhack_is_ctrl_pressed())) ? 1 : 0;
+        (conf_get_int(term->conf, CONF_url_underline) == URLHACK_UNDERLINE_HOVER && (!conf_get_bool(term->conf, CONF_url_ctrl_click) || urlhack_is_ctrl_pressed())) ? 1 : 0;
 
     int urlhack_is_link = 0, urlhack_hover_current = 0;
     int urlhack_toggle_x = term->cols, urlhack_toggle_y = term->rows;
@@ -6628,7 +6628,7 @@ void term_mouse(Terminal *term, Mouse_Button braw, Mouse_Button bcooked,
 	deselect(term);
 	term->selstate = NO_SELECTION;
 
-	if ((!conf_get_int(term->conf, CONF_url_ctrl_click) || (conf_get_int(term->conf, CONF_url_ctrl_click) && urlhack_is_ctrl_pressed())) && urlhack_is_in_link_region(x, y)) {
+	if ((!conf_get_bool(term->conf, CONF_url_ctrl_click) || (conf_get_bool(term->conf, CONF_url_ctrl_click) && urlhack_is_ctrl_pressed())) && urlhack_is_in_link_region(x, y)) {
 		int i;
 		char *linkbuf = NULL;
 		text_region region = urlhack_get_link_bounds(x, y);
@@ -6665,7 +6665,7 @@ void term_mouse(Terminal *term, Mouse_Button braw, Mouse_Button bcooked,
 			unlineptr(urldata);
 		}
 		
-		urlhack_launch_url(!conf_get_int(term->conf, CONF_url_defbrowser) ? conf_get_filename(term->conf, CONF_url_browser)->path : NULL, linkbuf);
+		urlhack_launch_url(!conf_get_bool(term->conf, CONF_url_defbrowser) ? conf_get_filename(term->conf, CONF_url_browser)->path : NULL, linkbuf);
 		
 		sfree(linkbuf);
 	}

--- a/windows/window.c
+++ b/windows/window.c
@@ -888,7 +888,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show)
 	 * HACK: PuttyTray / Nutty
 	 * Hyperlink stuff: Set the regular expression
 	 */
-	if (conf_get_int(term->conf, CONF_url_defregex) == 0) {
+	if (conf_get_bool(term->conf, CONF_url_defregex) == 0) {
 		urlhack_set_regular_expression(conf_get_str(term->conf, CONF_url_regex));
 	}
 
@@ -2418,7 +2418,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 		 * HACK: PuttyTray / Nutty
 		 * Reconfigure
 		 */
-		if (conf_get_int(conf, CONF_url_defregex) == 0) {
+		if (conf_get_bool(conf, CONF_url_defregex) == 0) {
 			urlhack_set_regular_expression(conf_get_str(conf, CONF_url_regex));
 		}
 		term->url_update = TRUE;
@@ -2756,7 +2756,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 		urlhack_mouse_old_x = TO_CHR_X(X_POS(lParam));
 		urlhack_mouse_old_y = TO_CHR_Y(Y_POS(lParam));
 
-		if ((!conf_get_int(term->conf, CONF_url_ctrl_click) || urlhack_is_ctrl_pressed()) &&
+		if ((!conf_get_bool(term->conf, CONF_url_ctrl_click) || urlhack_is_ctrl_pressed()) &&
 			urlhack_is_in_link_region(urlhack_mouse_old_x, urlhack_mouse_old_y)) {
 				if (urlhack_cursor_is_hand == 0) {
 					SetClassLongPtr(hwnd, GCLP_HCURSOR, (LONG_PTR)LoadCursor(NULL, IDC_HAND));
@@ -3254,7 +3254,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 	return false;
       case WM_KEYDOWN:
 	/* HACK: PuTTY-url: Change cursor if we are in ctrl+click link mode (spans multiple switch cases) */
-		if (wParam == VK_CONTROL && conf_get_int(term->conf, CONF_url_ctrl_click)) {
+		if (wParam == VK_CONTROL && conf_get_bool(term->conf, CONF_url_ctrl_click)) {
 			GetCursorPos(&cursor_pt);
 			ScreenToClient(hwnd, &cursor_pt);
 
@@ -3267,7 +3267,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 		}	
       case WM_SYSKEYDOWN:
       case WM_KEYUP:
-		if (wParam == VK_CONTROL && conf_get_int(term->conf, CONF_url_ctrl_click)) {
+		if (wParam == VK_CONTROL && conf_get_bool(term->conf, CONF_url_ctrl_click)) {
 			SetCursor(LoadCursor(NULL, IDC_IBEAM));
 			term_update(term);
 		}


### PR DESCRIPTION
There was a mismatch in declaring and processing of checkboxes.
Starting from putty 0.71 there is a get_bool method which should be used to get checkbox values